### PR TITLE
Added slider dots above the slider component to show current active slide

### DIFF
--- a/src/Components/SliderComponent.js
+++ b/src/Components/SliderComponent.js
@@ -27,12 +27,28 @@ export default function SliderComponent() {
   ];
 
   var settings = {
+    dots: true,
     arrows: false,
     infinite: true,
     speed: 500,
     slidesToShow: 1,
     slidesToScroll: 1,
-
+    appendDots: dots => (
+      <div
+        style={{
+          backgroundColor: "#dddddd00",
+          borderRadius: "10px",
+          padding: "0px",
+          position: 'absolute',
+          top: "-7%",
+          left: "50%",
+          transform: "translatex(-50%)",
+          Zindex: -1
+        }}
+      >
+        <ul style={{ margin: "0px", padding: 0 }}> {dots} </ul>
+      </div>
+    ),
   };
   const handleNext = () => {
     rs.current.slickNext();
@@ -100,7 +116,7 @@ export default function SliderComponent() {
         </Grid>
 
       </Grid>
-      <div style={{ marginTop: "60px" }}>
+      <div style={{ marginTop: "60px", position: "relative" }}>
         <Slider {...settings} ref={rs} >
           <Grid container sx={{ display: "flex !important"}}>
             {showComponent()}


### PR DESCRIPTION
## Previous Behaviour
<a href="https://user-images.githubusercontent.com/89798093/224475723-a96e8acc-12c6-4400-a563-c0b45f77ebe3.png"><img src="https://user-images.githubusercontent.com/89798093/224475723-a96e8acc-12c6-4400-a563-c0b45f77ebe3.png" alt=""/></a>

No slider dots indicating current acitive slide

## Current Behaviour
<a href="https://ibb.co/9t0jsvh"><img src="https://i.ibb.co/16Nx8nM/Screenshot-2023-03-13-3-25-40-PM.png" alt="" /></a>

Slider dots are visibly showing the current active slide
