### PR TITLE
Add top padding of 40px to "About the Community" text

### DIFF
--- a/src/Components/AboutSection.js
+++ b/src/Components/AboutSection.js
@@ -36,6 +36,7 @@ const AboutSection = () => {
               fontSize: { xs: "40px", sm: "48px" },
               fontWeight: "bold",
               fontFamily: "Roboto, Helvetica, Arial, sans-serif",
+              paddingTop: { xs: "2.5rem", sm: "2.67rem" },
             }}
           >
             <span


### PR DESCRIPTION

This PR fixes #87 

This PR adds a top padding of 40px to the "About the Community" text in the AboutSection component using relative rem units. The new padding is calculated based on the default font size and line height of the typography component.

To achieve this, I added the paddingTop property to the Typography component that contains the text and set it to 2.5rem for xs screen sizes and 2.67rem for sm screen sizes. I also updated the inline comments to reflect the changes.

This change improves the spacing and layout of the "About the Community" section, making it more readable and visually appealing

Screenshots for the change:
Before:
![befor](https://user-images.githubusercontent.com/97173732/228366704-8e282640-7039-4839-88f1-e6b79c035915.png)

After:
![after](https://user-images.githubusercontent.com/97173732/228366699-061888ea-acfc-4a68-b4b7-f7d2ef92c323.png)
