### PR TITLE
fix: fixed header file , ITM gwalior was overlapping

### DIFF
--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -40,7 +40,7 @@ export default function Header(props) {
                 color: "#959595",
                 fontSize: "14.74px",
                 fontFamily: "Roboto",
-                paddingTop: "2px",
+                paddingTop: "3px",
               }}
             >
               ITM Gwalior

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -40,6 +40,7 @@ export default function Header(props) {
                 color: "#959595",
                 fontSize: "14.74px",
                 fontFamily: "Roboto",
+                paddingTop: "2px",
               }}
             >
               ITM Gwalior


### PR DESCRIPTION
**Notes for Reviewers**

<!--tag the issue id  -->
This PR fixes #101 

Describe the changes you've made:
adding padding to the top , which downshifts the `ITM gwalior` text a bit. Works perfectly for mobile and pc after fix  



Screenshots for the change:
-BEFORE: 

![before](https://user-images.githubusercontent.com/104521101/229278762-596c9ecc-de1f-4017-8828-96599d24f8ed.png)

-AFTER:

![fix1](https://user-images.githubusercontent.com/104521101/229278780-3aa4ed19-2b83-41af-97dd-689e5cf72d11.png)




