### PR TITLE
Making Team Section Little Responsive

### DIFF
--- a/src/Components/SliderComponent.js
+++ b/src/Components/SliderComponent.js
@@ -248,10 +248,10 @@ export default function SliderComponent() {
       </Grid>
       <div style={{ marginTop: "60px", position: "relative" }}>
         <Slider {...settings} ref={rs}>
-          <Grid container sx={{ display: "flex !important" }}>
+          <Grid container sx={{ repeat(auto-fill, minmax(22rem, 2fr)) }}>
             {showComponent()}
           </Grid>
-          <Grid container sx={{ display: "flex !important" }}>
+          <Grid container sx={{ repeat(auto-fill, minmax(22rem, 2fr))}}>
             {showComponent()}
           </Grid>
         </Slider>


### PR DESCRIPTION
I have used grid to make the teams section responsive

**Notes for Reviewers**

<!--tag the issue id  -->
This PR fixes #48 

Describe the changes you've made:
I have used grid instead of flex and made the only one team member should use the whole width in the mobile view 



Screenshots for the change:

![Screenshot_20230402-221919_Chrome](https://user-images.githubusercontent.com/78336507/229367154-eb10b683-9452-4fee-a9f2-90dd80195b85.png)

<!--
Thank you for contributing to GDSCITM! 

Contributing Conventions:
- Include descriptive PR titles with [<SliderComponent>] prepended.


By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->