### PR TITLE
removed the empty space on the right of the header and shifted buttons

### DIFF
--- a/src/Components/Alternative/Header.module.css
+++ b/src/Components/Alternative/Header.module.css
@@ -36,7 +36,8 @@
     height: auto;
     display: flex;
     gap: 10px;
-    justify-content: center;
+    margin-right: 20px;
+    justify-content: flex-end;
     align-items: center;
 }
 
@@ -154,7 +155,8 @@
         height: auto;
         display: flex;
         gap: 10px;
-        justify-content: center;
+        margin-right: 20px;
+        justify-content: flex-end;
         align-items: center;
     }
 


### PR DESCRIPTION
**Notes for Reviewers**

<!--tag the issue id  -->
This PR fixes #129 

Describe the changes you've made:

removed the empty space on the right of the header and shifted buttons (changes made to "src/Components/Alternative/Header.module.css")

Screenshots for the change:

![2c5251724a69638f35dd0b685b757ab9](https://user-images.githubusercontent.com/107242590/230161622-6498065e-80cc-4d9c-bd8d-dac420fa274d.png)


<!--
Thank you for contributing to GDSCITM! 

Contributing Conventions:
- Include descriptive PR titles with [<component-name>] prepended.


By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->